### PR TITLE
fix: handle manual compose deployment

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -13,18 +13,18 @@ services:
     # ports:
     #   - "5432:5432"
 
-  caddy:
-    image: caddy:2.7-alpine
-    restart: unless-stopped
-    volumes:
-      - ./.volumes/caddy/data:/data
-      - ./.volumes/caddy/config:/config
-      - ./.volumes/caddy/Caddyfile:/etc/caddy/Caddyfile
-    ports:
-      # http
-      - "80:80"
-      # https
-      - "443:443"
+#  caddy:  # [PROXY]
+#    image: caddy:2.7-alpine  # [PROXY]
+#    restart: unless-stopped  # [PROXY]
+#    volumes:  # [PROXY]
+#      - ./.volumes/caddy/data:/data  # [PROXY]
+#      - ./.volumes/caddy/config:/config  # [PROXY]
+#      - ./.volumes/caddy/Caddyfile:/etc/caddy/Caddyfile  # [PROXY]
+#    ports:  # [PROXY]
+#      # http  # [PROXY]
+#      - "80:80"  # [PROXY]
+#      # https  # [PROXY]
+#      - "443:443"  # [PROXY]
 
   core:
     image: ghcr.io/defguard/defguard:${CORE_IMAGE_TAG:-latest}

--- a/docker-compose/setup.sh
+++ b/docker-compose/setup.sh
@@ -92,6 +92,9 @@ main() {
 		fetch_base_compose_file
 	fi
 
+	# enable reverse proxy in compose file
+	uncomment_feature "PROXY" "${PROD_COMPOSE_FILE}"
+
 	# enable enrollment service in compose file
 	if [ "$CFG_ENABLE_ENROLLMENT" ]; then
 		enable_enrollment


### PR DESCRIPTION
Disabled reverse proxy in the compose file to prevent issues when attempting to deploy manually (without using the one-line script).