### PR TITLE
Fix ConfigMap parsing issue in defguard-proxy

### DIFF
--- a/charts/defguard-proxy/templates/config.yaml
+++ b/charts/defguard-proxy/templates/config.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "defguard-proxy.labels" . | nindent 4 }}
 data:
-  DEFGUARD_PROXY_HTTP_PORT: {{ .Values.service.ports.http }}
-  DEFGUARD_PROXY_GRPC_PORT: {{ .Values.service.ports.grpc }}
+  DEFGUARD_PROXY_HTTP_PORT: {{ .Values.service.ports.http | quote }}
+  DEFGUARD_PROXY_GRPC_PORT: {{ .Values.service.ports.grpc | quote }}


### PR DESCRIPTION
This resolves the error that occurs when trying to apply the helm chart with defguard-proxy enabled.

```
Error: INSTALLATION FAILED: 1 error occurred:
        * ConfigMap in version "v1" cannot be handled as a ConfigMap: json: cannot unmarshal number into Go struct field ConfigMap.data of type string
```