### PR TITLE
Fix OpenID Secret Deployments

### DIFF
--- a/charts/defguard/templates/openid-secret.yaml
+++ b/charts/defguard/templates/openid-secret.yaml
@@ -1,7 +1,7 @@
 {{- $openIdKey := (genPrivateKey "rsa") | b64enc | quote }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.openIdKey) }}
 {{- if $secret }}
-{{- $password = index $secret.data "openid-key" }}
+{{- $openIdKey = index $secret.data "openid-key" }}
 {{- end }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
```bash
➜  ~ helm upgrade --install --namespace defguard defguard defguard/defguard -f values.yaml --debug
history.go:56: [debug] getting history for release defguard
upgrade.go:150: [debug] preparing upgrade for defguard
Error: UPGRADE FAILED: template: defguard/templates/openid-secret.yaml:4:35: executing "defguard/templates/openid-secret.yaml" at <"openid-key">: undefined variable: $password
helm.go:84: [debug] template: defguard/templates/openid-secret.yaml:4:35: executing "defguard/templates/openid-secret.yaml" at <"openid-key">: undefined variable: $password
UPGRADE FAILED
main.newUpgradeCmd.func2
        helm.sh/helm/v3/cmd/helm/upgrade.go:209
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.6.1/command.go:916
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.6.1/command.go:1044
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.6.1/command.go:968
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
        runtime/proc.go:250
runtime.goexit
        runtime/asm_arm64.s:1172
```