### PR TITLE
Fix openid-secret.yaml

### DIFF
--- a/charts/defguard/templates/openid-secret.yaml
+++ b/charts/defguard/templates/openid-secret.yaml
@@ -1,7 +1,7 @@
 {{- $openIdKey := (genPrivateKey "rsa") | b64enc | quote }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.openIdKey) }}
 {{- if $secret }}
-{{- $password = index $secret.data "openid-key" }}
+{{- $openIdKey = index $secret.data "openid-key" }}
 {{- end }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Right now after the first deployment when the secret is found the deployment will fail since the password variable is not defined, though it was a copy-paste typo.