### PR TITLE
Update config.yaml

### DIFF
--- a/charts/defguard-proxy/templates/config.yaml
+++ b/charts/defguard-proxy/templates/config.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "defguard-proxy.labels" . | nindent 4 }}
 data:
-  DEFGUARD_PROXY_HTTP_PORT: {{ .Values.service.ports.http }}
-  DEFGUARD_PROXY_GRPC_PORT: {{ .Values.service.ports.grpc }}
+  DEFGUARD_PROXY_HTTP_PORT: {{ .Values.service.ports.http | quote }}
+  DEFGUARD_PROXY_GRPC_PORT: {{ .Values.service.ports.grpc | quote }}


### PR DESCRIPTION
Right now the ConfigMap for defguard-proxy could not be generated since "data" expects strings only.