### PR TITLE
Make ingress config compatible with AWS ALB

### DIFF
--- a/charts/defguard-proxy/templates/ingress-grpc.yaml
+++ b/charts/defguard-proxy/templates/ingress-grpc.yaml
@@ -35,7 +35,7 @@ spec:
     - host: {{ .Values.ingress.grpc.host | quote }}
       http:
         paths:
-          - path: /
+          - path: /*
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}

--- a/charts/defguard-proxy/templates/ingress-web.yaml
+++ b/charts/defguard-proxy/templates/ingress-web.yaml
@@ -35,7 +35,7 @@ spec:
     - host: {{ .Values.ingress.web.host | quote }}
       http:
         paths:
-          - path: /
+          - path: /*
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}

--- a/charts/defguard/templates/ingress-grpc.yaml
+++ b/charts/defguard/templates/ingress-grpc.yaml
@@ -35,7 +35,7 @@ spec:
     - host: {{ .Values.ingress.grpc.host | quote }}
       http:
         paths:
-          - path: /
+          - path: /*
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}

--- a/charts/defguard/templates/ingress-web.yaml
+++ b/charts/defguard/templates/ingress-web.yaml
@@ -35,7 +35,7 @@ spec:
     - host: {{ .Values.ingress.web.host | quote }}
       http:
         paths:
-          - path: /
+          - path: /*
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}


### PR DESCRIPTION
AWS ALB needs to have a wildcard syntax to allow any additional pathes except of `/`. With current syntax ALB will return 404 error.