### PR TITLE
fix default core config

### DIFF
--- a/charts/defguard/templates/defguard-config.yaml
+++ b/charts/defguard/templates/defguard-config.yaml
@@ -14,6 +14,7 @@ data:
   DEFGUARD_DB_NAME: {{ .Values.postgresql.auth.database }}
   DEFGUARD_DB_USER: {{ .Values.postgresql.auth.username }}
   DEFGUARD_GRPC_PORT: {{ .Values.service.grpc.port | quote }}
+  DEFGUARD_HTTP_PORT: {{ .Values.service.web.port | quote }}
   DEFGUARD_ENROLLMENT_URL: {{ index .Values "defguard-proxy" "publicUrl" }}
   {{- if .Values.proxyUrl }}
   DEFGUARD_PROXY_URL: {{ .Values.proxyUrl }}

--- a/charts/defguard/values.yaml
+++ b/charts/defguard/values.yaml
@@ -1,6 +1,6 @@
 ---
 # this should be a URL based on defguard-proxy.ingress.grpc.host
-proxyUrl: "http://defguard-proxy-grpc.local"
+proxyUrl: ""
 # this should be a URL based on ingress.web.host
 publicUrl: "http://defguard.local"
 # defguard-core pod autoscaling configuration


### PR DESCRIPTION
- remove default proxy URL to avoid issues when not deploying proxy
- set http port configuration to align with service configuration