### PR TITLE
Auto apply masquarade in one liner 2.0

### DIFF
--- a/docker-compose2.0/setup.sh
+++ b/docker-compose2.0/setup.sh
@@ -96,16 +96,23 @@ usage() {
   echo "Usage: $(basename "$0") [OPTIONS]"
   echo
   echo "Available options:"
-  echo "  --dev           use development images"
-  echo "  --pre-release   use pre-release images"
-  echo "  --help          show this help and exit"
+  echo "  --dev             use development images"
+  echo "  --pre-release     use pre-release images"
+  echo "  --no-masquerade   disable IP masquerade on the gateway"
+  echo "  --help            show this help and exit"
   echo
   exit 0
 }
 
 parse_args() {
+    # Since the Gateway is running entirely in the Container,
+    # the masquerade is added by default to ensure it can access the host network.
+  MASQUERADE=true
   while [[ $# -gt 0 ]]; do
     case "$1" in
+      --no-masquerade)
+        MASQUERADE=false
+        shift ;;
       --dev)
         IMAGE_MODE="dev"
         DEFGUARD_CORE_TAG="dev"
@@ -226,9 +233,11 @@ POSTGRES_PASSWORD=${db_password}
 DEFGUARD_DB_NAME=defguard
 DEFGUARD_DB_USER=defguard
 DEFGUARD_DB_PASSWORD=${db_password}
+
+DEFGUARD_MASQUERADE=${MASQUERADE}
 EOF
 
-  success ".env written."
+    success ".env written"
 }
 
 launch() {


### PR DESCRIPTION
New one liner launches gateway entirely within a container (no network_mode: host). This makes it pretty useless without masquerade, since packets can't leave the container. This applies masquerade by default with an option to turn it off if someone would prefer a more advanced setup.